### PR TITLE
Strongly typed Query parameter

### DIFF
--- a/PSFlurl.Types.ps1xml
+++ b/PSFlurl.Types.ps1xml
@@ -6,4 +6,10 @@
             <TypeName>PSFlurl.TypeConverters.UrlTypeConverter</TypeName>
         </TypeConverter>
     </Type>
+        <Type>
+        <Name>Flurl.QueryParamCollection</Name>
+        <TypeConverter>
+            <TypeName>PSFlurl.TypeConverters.QueryTypeConverter</TypeName>
+        </TypeConverter>
+    </Type>
 </Types>

--- a/src/PSFlurl/Attributes/FluentQueryTransformAttribute.cs
+++ b/src/PSFlurl/Attributes/FluentQueryTransformAttribute.cs
@@ -1,15 +1,21 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Management.Automation;
 using Flurl;
 using PSFlurl.Extensions;
 
+/// <summary>
+/// Transforms generic array/IEnumerable Query input to a <see cref="QueryParamCollection"/>.
+/// </summary>
 namespace PSFlurl.Attributes {
     [AttributeUsage(AttributeTargets.Property)]
     public class FluentQueryTransformAttribute : ArgumentTransformationAttribute {
+
+        private static readonly TypeConverter _queryConverter = TypeDescriptor.GetConverter(typeof(QueryParamCollection));
+
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData) {
             return TransformQuery(inputData);
         }
@@ -20,74 +26,32 @@ namespace PSFlurl.Attributes {
                 query = psObject.BaseObject;
             }
 
-            // Return QueryParamCollection as-is
-            if (query is QueryParamCollection qpc) {
-                return qpc;
-            }
-
-            // Convert known types to QueryParamCollection
             var qcpFromQuery = new QueryParamCollection();
             switch (query) {
-                case string queryString:
-                    qcpFromQuery = new QueryParamCollection(queryString);
-                    break;
-
                 case object[] array when array.Length > 0 && array[0] is string:
                     qcpFromQuery = new QueryParamCollection(string.Join("&", array));
                     break;
 
                 case object[] array when array.Length > 0 && array[0] is IDictionary:
-                    foreach (IDictionary dict in array.Cast<IDictionary>()) {
-                        qcpFromQuery.AddRange(dict.Cast<DictionaryEntry>()
-                            .Select(e => new KeyValuePair<string, object>(e.Key.ToString(), e.Value)), NullValueHandling.Ignore);
-                    }
-                    break;
-
-                case object obj when obj.GetType().Name.StartsWith("ValueTuple`2") || obj.GetType().Name.StartsWith("Tuple`2"):
-                    Type tupleType = obj.GetType();
-                    string item1 = tupleType.GetField("Item1")?.GetValue(obj)?.ToString() ??
-                                  tupleType.GetProperty("Item1")?.GetValue(obj)?.ToString();
-                    object item2 = tupleType.GetField("Item2")?.GetValue(obj) ??
-                                  tupleType.GetProperty("Item2")?.GetValue(obj);
-                    if (item1 != null) {
-                        qcpFromQuery.AddRange(new[] { new KeyValuePair<string, object>(item1, item2) }, NullValueHandling.Ignore);
-                    }
+                    array.Cast<IDictionary>()
+                        .SelectMany(dict => ((QueryParamCollection)_queryConverter.ConvertFrom(dict)))
+                        .ToList()
+                        .ForEach(param => qcpFromQuery.Add(param.Name, param.Value));
                     break;
 
                 case IEnumerable<object> enumObj when enumObj.All(x =>
                     x.GetType().Name.StartsWith("ValueTuple`2") || x.GetType().Name.StartsWith("Tuple`2")):
-                    IEnumerable<KeyValuePair<string, object>> kvps = enumObj.Select(tuple => {
-                        Type enumTupleType = tuple.GetType();
-                        string enumItem1 = enumTupleType.GetField("Item1")?.GetValue(tuple)?.ToString() ??
-                                       enumTupleType.GetProperty("Item1")?.GetValue(tuple)?.ToString();
-                        object enumItem2 = enumTupleType.GetField("Item2")?.GetValue(tuple) ??
-                                       enumTupleType.GetProperty("Item2")?.GetValue(tuple);
-                        return new KeyValuePair<string, object>(enumItem1, enumItem2);
-                    }).Where(kvp => kvp.Key != null);
-                    qcpFromQuery.AddRange(kvps, NullValueHandling.Ignore);
+                    enumObj
+                        .SelectMany(tuple => ((QueryParamCollection)_queryConverter.ConvertFrom(tuple)))
+                        .ToList()
+                        .ForEach(param => qcpFromQuery.Add(param.Name, param.Value));
                     break;
 
                 case IEnumerable<KeyValuePair<string, object>> kvp:
                     qcpFromQuery.AddRange(kvp, NullValueHandling.Ignore);
                     break;
-
-                case IDictionary dict:
-                    qcpFromQuery.AddRange(dict.Cast<DictionaryEntry>()
-                        .Select(e => new KeyValuePair<string, object>(e.Key.ToString(), e.Value)), NullValueHandling.Ignore);
-                    break;
-
-                case NameValueCollection nvc:
-                    qcpFromQuery.AddRange(nvc.AllKeys.SelectMany(key =>
-                        nvc.GetValues(key).Select(value =>
-                            new KeyValuePair<string, object>(key, value))), NullValueHandling.Ignore);
-                    break;
-
-                case Url url:
-                    qcpFromQuery = url.QueryParams;
-                    break;
-
+                    
                 default:
-                    Console.WriteLine("Unhandled type: " + query.GetType().FullName);
                     // Return unhandled types as-is
                     return query;
             }

--- a/src/PSFlurl/Cmdlets/NewFlQuery.cs
+++ b/src/PSFlurl/Cmdlets/NewFlQuery.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 using Flurl;
 using PSFlurl.Attributes;
-using PSFlurl.Extensions;
-using PSFlurl.Utilities;
 
 namespace PSFlurl.Cmdlets {
     [Cmdlet(VerbsCommon.New, "FlQuery")]
@@ -15,14 +10,14 @@ namespace PSFlurl.Cmdlets {
     [OutputType(typeof(QueryParamCollection))]
     public class NewFlQueryCommand : PSCmdlet {
 
-        private QueryParamCollection _queryParams = new QueryParamCollection();
+        private readonly QueryParamCollection _queryParams = new QueryParamCollection();
 
         /// <summary>
         /// <para type="description">The query parameters.</para>
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [FluentQueryTransform()]
-        public object Query { get; set; }
+        public QueryParamCollection Query { get; set; }
 
         /// <summary>
         /// <para type="description">Specifies how to handle null values in the query parameters.</para>
@@ -44,51 +39,14 @@ namespace PSFlurl.Cmdlets {
 
         protected override void ProcessRecord() {
             if (Query != null) {
-                if (Query is QueryParamCollection collection) {
-                    IEnumerable<KeyValuePair<string, object>> kvpEnumerable = QueryParamCollectionConverter.ConvertToKeyValuePairs(collection);
-                    _queryParams.AddRange(kvpEnumerable, NullValueHandling);
+                foreach ((string Name, object Value) in Query) {
+                    object val = Value != null && string.IsNullOrWhiteSpace($"{Value}") ? null : Value;
+                    _queryParams.Add(Name, val, false, NullValueHandling);
                 }
-                else if (Query is IEnumerable<KeyValuePair<string, object>> kvpEnumerable) {
-                    _queryParams.AddRange(kvpEnumerable, NullValueHandling);
-                }
-                else if (Query.GetType().Name.StartsWith("ValueTuple`2") || Query.GetType().Name.StartsWith("Tuple`2")) {
-                    Type tupleType = Query.GetType();
-                    string item1 = tupleType.GetField("Item1")?.GetValue(Query)?.ToString();
-                    object item2 = tupleType.GetField("Item2")?.GetValue(Query);
-                    if (item1 != null) {
-                        _queryParams.Add(item1, item2, false, NullValueHandling);
-                    }
-                }
-                else {
-                    WriteError(new ErrorRecord(
-                        new ArgumentException($"Query ({Query.GetType().FullName}) must be string(s), IDictionary(s), Tuples(s), NameValueCollection, QueryParamCollection, or IEnumerable<KeyValuePair<string, object>>"),
-                        "InvalidArgument",
-                        ErrorCategory.InvalidArgument,
-                        Query));
-                }
-            }
-
-            // Only output immediately if we're not using the pipeline
-            if (!MyInvocation.BoundParameters.ContainsKey(nameof(Query)) ||
-                !GetType().GetProperty(nameof(Query)).GetCustomAttributes(typeof(ParameterAttribute), true)
-                    .Cast<ParameterAttribute>()
-                    .Any(a => a.ValueFromPipeline)) {
-                OutputResult();
             }
         }
 
         protected override void EndProcessing() {
-            // Only params accumulated from the pipeline
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(Query)) &&
-                GetType().GetProperty(nameof(Query)).GetCustomAttributes(typeof(ParameterAttribute), true)
-                    .Cast<ParameterAttribute>()
-                    .Any(a => a.ValueFromPipeline)) {
-                OutputResult();
-            }
-            base.EndProcessing();
-        }
-
-        private void OutputResult() {
             if (AsString.IsPresent || EncodeSpaceAsPlus.IsPresent) {
                 WriteObject(_queryParams.ToString(EncodeSpaceAsPlus.IsPresent));
             }

--- a/src/PSFlurl/ModuleInitializer.cs
+++ b/src/PSFlurl/ModuleInitializer.cs
@@ -6,9 +6,10 @@ using PSFlurl.TypeConverters;
 namespace PSFlurl {
     public class ModuleInitializer : IModuleAssemblyInitializer {
         public void OnImport() {
-            var typeConverter = new UrlTypeConverter();
-            var attribute = new TypeConverterAttribute(typeof(UrlTypeConverter));
-            TypeDescriptor.AddAttributes(typeof(Url), attribute);
+            var queryConverterAttribute = new TypeConverterAttribute(typeof(QueryTypeConverter));
+            var urlConverterAttribute = new TypeConverterAttribute(typeof(UrlTypeConverter));
+            TypeDescriptor.AddAttributes(typeof(QueryParamCollection), queryConverterAttribute);
+            TypeDescriptor.AddAttributes(typeof(Url), urlConverterAttribute);
         }
     }
 }

--- a/src/PSFlurl/TypeConverters/QueryTypeConverter.cs
+++ b/src/PSFlurl/TypeConverters/QueryTypeConverter.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using Flurl;
+using PSFlurl.Extensions;
+
+namespace PSFlurl.TypeConverters {
+    public class QueryTypeConverter : TypeConverter {
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) {
+            if (sourceType == typeof(string) ||
+                sourceType == typeof(Url) ||
+                sourceType.Name.StartsWith("ValueTuple`2") ||
+                sourceType.Name.StartsWith("Tuple`2") ||
+                typeof(IDictionary).IsAssignableFrom(sourceType) ||
+                typeof(NameValueCollection).IsAssignableFrom(sourceType)
+            ) return true;
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
+            if (destinationType == typeof(string))
+                return true;
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
+            var qpc = new QueryParamCollection();
+
+            switch (value) {
+                case string str:
+                    return new QueryParamCollection(str);
+
+                case IDictionary dict:
+                    qpc.AddRange(dict.Cast<DictionaryEntry>()
+                        .Select(e => new KeyValuePair<string, object>(e.Key.ToString(), e.Value)),
+                        NullValueHandling.Ignore);
+                    return qpc;
+
+                case NameValueCollection nvc:
+                    qpc.AddRange(nvc.AllKeys.SelectMany(key =>
+                        nvc.GetValues(key).Select(val =>
+                            new KeyValuePair<string, object>(key, val))),
+                        NullValueHandling.Ignore);
+                    return qpc;
+
+                case Url url:
+                    return url.QueryParams;
+
+                case object obj when obj.GetType().Name.StartsWith("ValueTuple`2") ||
+                                   obj.GetType().Name.StartsWith("Tuple`2"):
+                    Type tupleType = obj.GetType();
+                    string item1 = tupleType.GetField("Item1")?.GetValue(obj)?.ToString() ??
+                                 tupleType.GetProperty("Item1")?.GetValue(obj)?.ToString();
+                    object item2 = tupleType.GetField("Item2")?.GetValue(obj) ??
+                                 tupleType.GetProperty("Item2")?.GetValue(obj);
+                    if (item1 != null) {
+                        qpc.AddRange(new[] { new KeyValuePair<string, object>(item1, item2) },
+                            NullValueHandling.Ignore);
+                    }
+                    return qpc;
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
+            if (value is QueryParamCollection qpc && destinationType == typeof(string)) {
+                return qpc.ToString();
+            }
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}


### PR DESCRIPTION
Query parameter type changed from [object] to [QueryParamCollection], for both New-Flurl and New-FlQuery.

The net impact is 36 fewer lines of code without any loss of functionality.  And the remaining lines are much easier to read and maintain.  Reinforcing the adage: [less > more](https://en.wikipedia.org/wiki/Less_(Unix)).

I struggled with PowerShell automatically enumerating pipelined objects and unexpectedly transforming others.  It resulted in a surprising variety of inputs including Hashtable(s), Tuple(s), and ValueTuple(s).  In some (direct binding) scenarios those were wrapped in PSObjects.  But I proceeded to bend it to my will.  Unfortunately, it wasn't until later it dawned on me that setting my Query parameter type to [object] was the root of the problem. I originally chose to do so with the goal of maximizing flexibility, which I ultimately achieved but with a lot of added complexity.

I couldn't help but think of a [@Gardenary](https://www.youtube.com/c/Gardenary/videos) video my wife was recently watching. Evidently, Gardenary is keen on saying _work with nature_ (something along the lines of planting food in the middle of your garden with flowers around to serve as a natural barrier for would-be pests, [but that's not important right now](https://www.sanspotter.com/wp-content/uploads/2020/09/airplane-movie-quotes-18.jpg)). I have no affiliation with Gardenary and, admittedly, didn't catch more than a few bits here and there in passing (and it was still more than enough!).

But, in the world of coding _nature_ is your processing _environment_. So,

**Lesson Learned: _work with nature_!**